### PR TITLE
Replace circular map markers with intuitive start/end location icons

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,24 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Support"
+    url: https://github.com/GoPredict/support
+    about: "If you're facing any issues, please contact us here!"
+templates:
+  - name: "Bug Report"
+    about: "Use this template to report a bug"
+    file: bug_report.md
+  - name: "Feature Request"
+    about: "Use this template to request a new feature"
+    file: feature_request.md
+  - name: "Style Enhancement"
+    about: "Use this template to suggest UI style changes"
+    file: style_enhancement.md
+  - name: "Documentation Update"
+    about: "Use this template to request a documentation update"
+    file: documentation_update.md
+  - name: "Pull Request"
+    about: "Use this template for submitting a pull request"
+    file: pull_request.md
+  - name: "Proposed Improvements"
+    about: "Use this template for proposing improvements"
+    file: proposed_improvements.md

--- a/.github/ISSUE_TEMPLATE/documentation_update.md
+++ b/.github/ISSUE_TEMPLATE/documentation_update.md
@@ -1,0 +1,22 @@
+---
+name: Documentation Update
+about: Suggest an update or fix for the project documentation.
+labels: documentation, enhancement
+---
+## Describe the update
+A clear description of the documentation update needed.
+
+## Problem
+What part of the documentation is incorrect, outdated, or missing?
+
+## Suggested Changes
+What specific changes or additions should be made to the documentation?
+
+## Expected Outcome
+How should the documentation look after the update?
+
+## Screenshots (if applicable)
+If relevant, include screenshots or examples to help clarify the changes.
+
+## Additional Context
+Provide any additional context for the proposed update.

--- a/.github/ISSUE_TEMPLATE/style_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/style_enhancement.md
@@ -1,0 +1,27 @@
+---
+name: Style Enhancement
+about: Suggest a UI or design-related improvement.
+labels: enhancement, style
+---
+## Describe the enhancement
+A clear and concise description of the styling issue or enhancement.
+
+## Current Behavior
+Describe the current state of the UI or design element.
+
+## Proposed Changes
+What specific changes or improvements would you like to see in the design or style?
+
+## Expected Outcome
+What should the UI look like after the changes are made?
+
+## Screenshots
+If applicable, add screenshots to help explain the problem or proposed solution.
+
+## Environment
+- **Operating System**: [e.g. macOS 12]
+- **Browser** (if frontend): [e.g. Chrome 90]
+- **App Version**: [e.g. v1.2.0]
+
+## Additional context
+Add any additional context or references here.

--- a/frontend/src/components/LeafletMap.tsx
+++ b/frontend/src/components/LeafletMap.tsx
@@ -5,20 +5,28 @@ import 'leaflet/dist/leaflet.css'
 // Fix for default markers not showing in bundled environments
 delete (L.Icon.Default.prototype as any)._getIconUrl
 
-// Create custom colored markers
+// Create a more beautiful, custom pin-style icon using SVG
 const createCustomIcon = (color: string) => {
+  // SVG for a classic map pin with enhanced styling
+  const markerHtml = `
+    <svg viewBox="0 0 32 48" width="32" height="48" style="filter: drop-shadow(0 4px 6px rgba(0,0,0,0.3));">
+      {/* The main pin shape with a white border for better contrast */}
+      <path
+        fill="${color}"
+        stroke="#FFFFFF"
+        stroke-width="2"
+        d="M16 2 C9.925 2 5 6.925 5 13 c0 7.875 11 23 11 23 s11 -15.125 11 -23 C27 6.925 22.075 2 16 2z"
+      />
+      {/* A white inner circle for a polished look */}
+      <circle cx="16" cy="13" r="5" fill="#FFFFFF" />
+    </svg>`
+
   return L.divIcon({
-    className: 'custom-marker',
-    html: `<div style="
-      background-color: ${color};
-      width: 20px;
-      height: 20px;
-      border-radius: 50%;
-      border: 3px solid white;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-    "></div>`,
-    iconSize: [20, 20],
-    iconAnchor: [10, 10],
+    className: 'leaflet-custom-icon',
+    html: markerHtml,
+    iconSize: [32, 48], // Size of the icon
+    iconAnchor: [16, 48], // Point of the icon which will correspond to marker's location
+    popupAnchor: [0, -48], // Point from which the popup should open relative to the iconAnchor
   })
 }
 
@@ -74,14 +82,14 @@ export default function LeafletMap({ from, to, animateKey }: LeafletMapProps) {
       markers = []
       if (from) {
         const startMarker = L.marker([from.lat, from.lon], {
-          icon: createCustomIcon('#10b981') // Green for start
+          icon: createCustomIcon('#2563eb'), // Blue pin for start
         }).addTo(map)
         startMarker.bindPopup(`<b>Start:</b> ${from.name || 'Start Location'}`)
         markers.push(startMarker)
       }
       if (to) {
         const endMarker = L.marker([to.lat, to.lon], {
-          icon: createCustomIcon('#ef4444') // Red for end
+          icon: createCustomIcon('#ef4444'), // Red pin for end
         }).addTo(map)
         endMarker.bindPopup(`<b>End:</b> ${to.name || 'End Location'}`)
         markers.push(endMarker)
@@ -156,5 +164,3 @@ export default function LeafletMap({ from, to, animateKey }: LeafletMapProps) {
     </div>
   )
 }
-
-


### PR DESCRIPTION
## Summary
Currently, the map in the GoPredict app uses simple circular markers to indicate the start and end locations.
This PR replaces them with more intuitive icons:
- Blue pin for the start location
- Red destination marker for the end location

## Changes
- [x] Frontend
- [ ] Backend
- [ ] Python ML
- [ ] Docs
- [ ] CI / Infra

## Checklist
- [x] I opened an issue and linked it (or this is a small tweak)
- [ ] I added/updated tests
- [x] `frontend`: `npm run test:run` passes
- [ ] `backend`: `npm test` passes
- [ ] CI passes on this PR
- [ ] Docs updated (README/CONTRIBUTING as needed)

## Screenshots (if UI)
<img width="845" height="495" alt="image" src="https://github.com/user-attachments/assets/19485b05-cd42-4613-9192-4138b9363bde" />
<img width="522" height="213" alt="image" src="https://github.com/user-attachments/assets/1527021a-c1a3-4bed-8352-ccbe0a2b8be5" />

## Notes for reviewers
