### PR TITLE
Fix: Location Dropdown reappearing issue

### DIFF
--- a/frontend/src/components/LocationSearch.tsx
+++ b/frontend/src/components/LocationSearch.tsx
@@ -71,17 +71,27 @@ export function LocationSearch({
 
   // Filter locations based on search input
   useEffect(() => {
+    if (!value.trim()) {
+      setSearchResults([]);
+      setIsOpen(false);
+      return;
+    }
+
+    // If the input exactly matches the selected location's name, keep the dropdown closed
+    if (selectedLocation && value.trim() === selectedLocation.name) {
+      setSearchResults([]);
+      setIsOpen(false);
+      return;
+    }
+
     if (value.trim()) {
       const filtered = locations.filter(location =>
         location.name.toLowerCase().includes(value.toLowerCase())
       );
       setSearchResults(filtered);
       setIsOpen(filtered.length > 0);
-    } else {
-      setSearchResults([]);
-      setIsOpen(false);
     }
-  }, [value, locations]);
+  }, [value, locations,  selectedLocation]);
 
   // Handle location selection
   const handleLocationSelect = (location: Location) => {


### PR DESCRIPTION
## Summary
Fixed a bug in LocationSearch where the dropdown stayed open after picking a location. Now, when you select a city, the dropdown closes right away, but the selected city stays in the input. The search and suggestions still work normally.

## Changes
- [x] Frontend
- [ ] Backend
- [ ] Python ML
- [ ] Docs
- [ ] CI / Infra

## Checklist
- [x] I opened an issue and linked it (or this is a small tweak)
- [ ] I added/updated tests
- [x] `frontend`: `npm run test:run` passes
- [ ] `backend`: `npm test` passes
- [ ] CI passes on this PR
- [ ] Docs updated (README/CONTRIBUTING as needed)


Issue linked https://github.com/harshitaphadtare/GoPredict/issues/6
